### PR TITLE
Fix autoupdate bug

### DIFF
--- a/src/install.sh
+++ b/src/install.sh
@@ -266,8 +266,13 @@ chmod +x /home/mediachain/bin/check-mcnode-release
 cat > /home/mediachain/bin/install-latest-mcnode  <<-"EOF"
 #!/bin/bash
 
-set -eux
+set -eu
 set -o pipefail
+
+# simple log fn to print with timestamp
+function log {
+ echo "[$(date --utc +%FT%TZ)] $1"
+}
 
 installed_version="none"
 if [ -e /home/mediachain/.deploy/mcnode-version ]; then
@@ -276,12 +281,12 @@ fi
 latest_version=$(/home/mediachain/bin/check-mcnode-release tag)
 
 if [ "${installed_version}" == "${latest_version}" ]; then
-    echo "Installed version is latest (${installed_version}), no need to update"
+    log "Installed version is latest (${installed_version}), no need to update"
     exit 0
 fi
 
-echo "Current mcnode version: ${installed_version}"
-echo "Installing latest mcnode version: ${latest_version}"
+log "Current mcnode version: ${installed_version}"
+log "Installing latest mcnode version: ${latest_version}"
 
 tarball_url=$(/home/mediachain/bin/check-mcnode-release tarball)
 curl -s -L ${tarball_url} > /home/mediachain/mcnode.tgz

--- a/src/install.sh
+++ b/src/install.sh
@@ -299,6 +299,7 @@ fi
 
 # stop concat service if it's already running
 if $concat_running; then
+    log "mcnode is running, stopping during install"
     sudo service concat stop
 fi
 
@@ -307,13 +308,16 @@ tar xzf /home/mediachain/mcnode.tgz -C /home/mediachain/bin
 echo ${latest_version} > /home/mediachain/.deploy/mcnode-version
 rm /home/mediachain/mcnode.tgz
 
-# make sure everything is still owned by mediachain, since this will run as root
+# make sure everything is still owned by mediachain, since this will run as root during initial setup
 chown -R mediachain:mediachain /home/mediachain
 
 # start concat service if we stopped it before
 if $concat_running; then
+    log "starting mcnode after update"
     sudo service concat start
 fi
+
+log "successfully updated mcnode to ${latest_version}"
 EOF
 
 _chown /home/mediachain/bin/install-latest-mcnode

--- a/src/install.sh
+++ b/src/install.sh
@@ -321,6 +321,8 @@ chmod -R 770 /home/mediachain/data
 # run the install script
 /home/mediachain/bin/install-latest-mcnode
 
+# Make sure cron runs with a sensible PATH
+crontab -l -u mediachain | { cat; echo "PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin"; } | crontab -u mediachain - || true
 # and add a cron job to update to the latest version every night at 3am
 crontab -l -u mediachain | { cat; echo "* 3 * * * /home/mediachain/bin/install-latest-mcnode >> /home/mediachain/logs/update_cron.log 2>&1"; } | crontab -u mediachain - || true
 


### PR DESCRIPTION
An incorrect PATH in the cron environment was causing our autoupdate script to fail 😞 

This fixes the PATH, and also adds timestamps to the log output and makes the log more informative.