### PR TITLE
Install gcc-5 for updated libstdc++ dependency

### DIFF
--- a/src/install.sh
+++ b/src/install.sh
@@ -132,6 +132,12 @@ _mkdir /home/mediachain/logs
 
 setState INSTALLING_SYSTEM_PACKAGES
 
+# install gcc-5 so we can get libc6 (required by recent concat versions / rocksdb)
+apt-get install -y software-properties-common
+apt-add-repository -y ppa:ubuntu-toolchain-r/test
+apt-get update
+apt-get install -y gcc-5 g++-5
+
 # Update packages and do basic security hardening
 apt-get upgrade -y
 

--- a/src/install.sh
+++ b/src/install.sh
@@ -132,7 +132,7 @@ _mkdir /home/mediachain/logs
 
 setState INSTALLING_SYSTEM_PACKAGES
 
-# install gcc-5 so we can get a libstdc++ compatible recent concat & rocksdb versions
+# install gcc-5 so we can get a libstdc++ compatible with recent concat & rocksdb versions
 apt-get install -y software-properties-common
 apt-add-repository -y ppa:ubuntu-toolchain-r/test
 apt-get update

--- a/src/install.sh
+++ b/src/install.sh
@@ -132,7 +132,7 @@ _mkdir /home/mediachain/logs
 
 setState INSTALLING_SYSTEM_PACKAGES
 
-# install gcc-5 so we can get libc6 (required by recent concat versions / rocksdb)
+# install gcc-5 so we can get a libstdc++ compatible recent concat & rocksdb versions
 apt-get install -y software-properties-common
 apt-add-repository -y ppa:ubuntu-toolchain-r/test
 apt-get update


### PR DESCRIPTION
Since rocksdb (and recent concat) requires gcc-5, we need the correct libstdc++ version to be present on the node.  This pulls in gcc-5 and g++-5 to get them.